### PR TITLE
[FIX]: Pipeline failure since `2023-12-29`  - JORAM PDF formatting issues

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -21,11 +21,8 @@ GASOLINE_95_TW = "Gasolina 95  "
 GASOLINE_98_TW = "Gasolina 98  "
 
 # PDF_GAS_PRICE_REGEX = r'(?<=€ )([\d,]+)(?= por litro)'
-PDF_GAS_PRICE_REGEX = r"(%s|%s|%s)(?:[\.€\w ]+)(\d{1},\d{3})" % (
-    "Gasolina super sem chumbo IO 95",
-    "Gasóleo rodoviário",
-    "Gasóleo colorido e marcado",
-)
+PDF_GAS_PRICE_REGEX = r"(Gasolina\s*super\s*sem\s*chumbo\s*IO\s*95|Gasóleo\s*rodoviário|Gasóleo\s*colorido\s*e\s*marcado)(?:[\.€\w ]+)(\d{1},\d{3})"
+
 
 # History plot
 HISTORY_PLOT_LABEL_GASOLINA_IO95 = "Gasolina IO95"
@@ -46,6 +43,10 @@ TWEET_HISTORY = (
     "Variação dos preços dos combustíveis na Madeira, de {start_date} a {end_date}."
 )
 
+# JORAM link 2023 - For Debugging
+JORAM_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%202023"
+JORAM_PDF_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%202023/{file}"
+
 # JORAM link
-JORAM_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%20{date:%Y}"
-JORAM_PDF_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%20{date:%Y}/{file}"
+#JORAM_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%20{date:%Y}"
+#JORAM_PDF_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%20{date:%Y}/{file}"

--- a/functions.py
+++ b/functions.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 from constants import COLORED_DIESEL, DIESEL, GASOLINE_95
 
@@ -21,7 +22,23 @@ def return_next_week_by_date(date):
 
 # Replace gas keys names. This function can be optimized
 def replace_gas_keys_names(gas_prices):
-    gas_prices[GASOLINE_95] = gas_prices.pop("Gasolina super sem chumbo IO 95")
-    gas_prices[DIESEL] = gas_prices.pop("Gasóleo rodoviário")
-    gas_prices[COLORED_DIESEL] = gas_prices.pop("Gasóleo colorido e marcado")
+    # Define a mapping of keys to their corresponding regular expression patterns
+    key_patterns = {
+        GASOLINE_95: re.compile(r"Gasolina\s*super\s*sem\s*chumbo\s*IO\s*95"),
+        DIESEL: re.compile(r"Gasóleo\s*rodoviário"),
+        COLORED_DIESEL: re.compile(r"Gasóleo\s*colorido\s*e\s*marcado"),
+    }
+
+    for target_key, pattern in key_patterns.items():
+        # Find the matching key using the regular expression
+        matching_key = next(
+            (key for key in gas_prices.keys() if pattern.match(key)), None
+        )
+
+        if matching_key:
+            # If a matching key is found, replace it
+            gas_prices[target_key] = gas_prices.pop(matching_key)
+        else:
+            print(f"Error: {target_key} key not found in the dictionary.")
+
     return gas_prices

--- a/update_gas_prices.py
+++ b/update_gas_prices.py
@@ -25,8 +25,11 @@ with open(CURRENT_GAS_INFO_FILE) as f:
 
 # Retrieve gas prices and creation date
 pdf_info = retrieve_newest_pdf_gas_info()
+print("🐞Debug: pdf_info =", pdf_info, "\n")
 gas_info = pdf_info["gas_info"]
+print("🐞Debug: gas_info =", gas_info, "\n")
 creation_date = pdf_info["creation_date"]
+print("🐞Debug: creation_date =", creation_date, "\n")
 
 # Retrieve week by creation date of the PDF
 start_date, end_date = retrieve_week_by_date(return_next_week_by_date(creation_date))


### PR DESCRIPTION
### Related issues

Closes #59 

### What does this PR do?

This PR fixes the issue where the current pipeline is failing due to the formatting issues with latest [PDF](https://joram.madeira.gov.pt/joram/2serie/Ano%20de%202023/IISerie-240-2023-12-29Supl3.pdf) by JORAM

### Solution Overview

- Add more robust matching 
- Add additional debug outputs
- Add a debug fall-back URL from 2023 (for future refs)

### Implementation Details

#### Matching & Catching
- [`constants.py:24`](https://github.com/carlosrsabreu/devo-abastecer/pull/58/files#diff-cfa78e49e2499e95798c1595f053646e7ff560961f38d907d4379082a0b05023R24-R25)
- [`functions.py:25`](https://github.com/carlosrsabreu/devo-abastecer/pull/58/files#diff-52c0e4b6841bd4f4a02e448335402ac42d01be84113d64602e93d56b9ac606efR25-R43)

#### Debugging
- [`constants.py:46`](https://github.com/carlosrsabreu/devo-abastecer/pull/58/files#diff-cfa78e49e2499e95798c1595f053646e7ff560961f38d907d4379082a0b05023R46-R49)
- [`update_gas_prices.py:28`](https://github.com/carlosrsabreu/devo-abastecer/pull/58/files#diff-392308a1955224b5b8f3cfd75ce87665df631eaf1a0e941b045f981dd8aece82R28-R32)

### ⚠️ Warning: 
The following alterations have to be done immediately after the first instance of the JORAM website publishes the page for the year 2024 ([Link](https://joram.madeira.gov.pt/joram/2serie/)):

```diff
# JORAM link 2023 - For Debugging
- JORAM_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%202023"
- JORAM_PDF_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%202023/{file}"
+ #JORAM_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%202023"
+ #JORAM_PDF_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%202023/{file}"

# JORAM link
- #JORAM_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%20{date:%Y}"
- #JORAM_PDF_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%20{date:%Y}/{file}"
+ JORAM_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%20{date:%Y}"
+ JORAM_PDF_LINK = "https://joram.madeira.gov.pt/joram/2serie/Ano%20de%20{date:%Y}/{file}"
```